### PR TITLE
audio: Reset primary output when closing stream.

### DIFF
--- a/hal/audio_hw.c
+++ b/hal/audio_hw.c
@@ -2358,6 +2358,9 @@ static void adev_close_output_stream(struct audio_hw_device *dev __unused,
             free(out->compr_config.codec);
     }
 
+    if (adev->primary_output == out)
+        adev->primary_output = NULL;
+
     if (adev->voice_tx_output == out)
         adev->voice_tx_output = NULL;
 


### PR DESCRIPTION
Primary output is not reset when the output is closed, so it is not
possible to open primary stream again unless the whole device is
reopened. Fix by reseting the primary output stream pointer when primary
output stream is closed.